### PR TITLE
Add ffmpeg acceleration support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 COPY requirements.txt .
 
 # Instala as dependências do Python
+RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copia a pasta src com o código do bot para o diretório de trabalho no container

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Este bot Telegram foi desenvolvido para transcrever áudios enviados pelos usuá
 
 Para instalar as dependências necessárias, execute o seguinte comando:
 
-`pip3 install -U -r requirements.txt` 
+`pip3 install -U -r requirements.txt`
 
 Certifique-se de que todas as dependências especificadas em `requirements.txt` estejam atualizadas.
+Além disso, o bot depende do `ffmpeg` para acelerar os áudios. Caso execute fora do Docker, instale o `ffmpeg` no seu sistema.
 
 ### Via Docker
 


### PR DESCRIPTION
## Summary
- allow configuring SPEED_UP_FACTOR and import subprocess
- add `speed_up_audio` to process audio with ffmpeg before transcription
- always download audio and clean up accelerated file
- install ffmpeg in Dockerfile
- document ffmpeg requirement

## Testing
- `python -m py_compile src/audio_handler.py src/replicate_client.py src/bot.py src/main.py src/errors.py`

------
https://chatgpt.com/codex/tasks/task_e_68646528be1c8331bce9e7dfc83d8ddb